### PR TITLE
now uses `/usr/bin/env python` to support any python install location

### DIFF
--- a/gtfoblookup.py
+++ b/gtfoblookup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 
 """Released as open source by NCC Group Plc - http://www.nccgroup.com/


### PR DESCRIPTION
Fixed #2 by replacing the shebang to use `/usr/bin/env python`.