### PR TITLE
Error when None

### DIFF
--- a/gtfoblookup.py
+++ b/gtfoblookup.py
@@ -467,7 +467,7 @@ def extractYmlLolbas(paths, attrs):
                                                             reset)
                                 if attr == "Command":
                                     line += dim
-                                line += cmd[attr]
+                                line += cmd[attr] if cmd[attr] else 'NA'
                                 line += reset
                                 subIndent = calcSubIndent(indent, attr, 3)
                                 print(textwrap.fill(line, width=80,


### PR DESCRIPTION
Using `./OtherMSBinaries/Remote.yml` (updated today) as an example, when running a command like `./gtfoblookup.py lolbas search -c exec remote` will give an error:
```
Traceback (most recent call last):
  [snip]
  File "./gtfoblookup.py", line 470, in extractYmlLolbas
    line += cmd[attr]
TypeError: can only concatenate str (not "NoneType") to str
```

This is because the yml file has and empty value (OperatingSystem):

    Category: Execute
    Privileges: User
    MitreID: T1127
    OperatingSystem: