### PR TITLE
Little wildcard "feature" ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ OPTIONS 'gtfoblookup.py gtfobins search'
        usage: gtfoblookup.py gtfobins search [-h] [-c categories] [-f] executable
 
        executable
-              the executable to search for
+              the executable to search for (can be `all`)
 
        -c categories, --category categories
               category or categories (comma separated) to search in
@@ -106,7 +106,7 @@ OPTIONS 'gtfoblookup.py lolbas search'
                                              executable
 
        executable
-              the executable to search for
+              the executable to search for (can be `all`)
 
        -c categories, --category categories
               category or categories (comma separated) to search in


### PR DESCRIPTION
Not really sure if it is just me wishing for something like this or not :D but here I am.

Sometimes I like to be lazy and have all the possible combinations in front of me so I don't really need to think too hard, for instance, if I want to get all the possible ways to download a file I could use this command:
```
./gtfoblookup.py gtfobins search -c download all
```
Same with `lolbas`.

_____

Also, realised that when searching for lolbas, it is impossible to find some files, for instance, searching for `DataSvcUtil` like so do not yield any result (also tried with lowercase, mixed, etc):
```
./gtfoblookup.py lolbas search -c upload DataSvcUtil
```
But when (using this code) searching for all `upload` functionalities, DataSvcUtil is the first result:
```
./gtfoblookup.py lolbas search -c upload all
```
It might be something kinda easy to find, probably just about the capitalization. I might look into that but not promising anything :D 